### PR TITLE
Correctif MVC Observer

### DIFF
--- a/src/model/Perspective.java
+++ b/src/model/Perspective.java
@@ -8,11 +8,7 @@ public class Perspective implements Observable {
 	private int x1, y1, x2, y2;	
 	File fichierImage;
 		
-	/**
-	 * Constructeur
-	 * @param obs l'observateur de cette perspective.
-	 */
-	public Perspective(Observateur obs) {
+	public void setObservateur(Observateur obs) {
 		this.obs = obs;
 	}
 	

--- a/src/model/Vignette.java
+++ b/src/model/Vignette.java
@@ -7,6 +7,10 @@ public class Vignette implements Observable {
 	Observateur obs;
 	File fichierImage;
 	
+	public void setObservateur(Observateur obs) {
+		this.obs = obs;
+	}
+	
 	public File getFichierImage() {
 		return fichierImage;
 	}
@@ -15,16 +19,7 @@ public class Vignette implements Observable {
 		this.fichierImage = fichierImage;
 		notifier();
 	}
-	
-
-	/**
-	 * Constructeur
-	 * @param obs l'observateur de cette vignette
-	 */
-	public Vignette(Observateur obs) {
-		this.obs = obs;
-	}
-	
+		
 	@Override
 	public void notifier() {
 		obs.update();

--- a/src/vue/FenetrePerspective.java
+++ b/src/vue/FenetrePerspective.java
@@ -3,13 +3,16 @@ package vue;
 import javax.swing.JInternalFrame;
 import javax.swing.JPanel;
 import model.Observateur;
+import model.Perspective;
 
+@SuppressWarnings("serial")
 public class FenetrePerspective extends JInternalFrame implements Observateur {
 	
 	// Attributs
 	JPanel perspective;
+	Perspective perspectiveM; //Le modèle de cette vue
 	
-	public FenetrePerspective(String label, int width, int height, int locationX, int locationY){
+	public FenetrePerspective(String label, int width, int height, int locationX, int locationY, Perspective perspectiveM){
 		super(label, true, true, true, true);
 		
 		// Specifications de la perspective
@@ -21,6 +24,9 @@ public class FenetrePerspective extends JInternalFrame implements Observateur {
 	    setSize(width, height);
 	    setLocation(locationX, locationY);
 	   	setVisible(true);
+	   	
+	   	this.perspectiveM = perspectiveM;
+	   	this.perspectiveM.setObservateur(this); //Enregistre cette vue auprès de son modèle en tant qu'observateur
 	}
 
 	@Override

--- a/src/vue/FenetrePrincipale.java
+++ b/src/vue/FenetrePrincipale.java
@@ -9,6 +9,10 @@ import java.awt.Toolkit;
 import javax.swing.JDesktopPane;
 import java.awt.GridLayout;
 
+import model.Perspective;
+import model.Vignette;
+
+@SuppressWarnings("serial")
 public class FenetrePrincipale extends JFrame {
 	
 	private JMenuBar menuBar;
@@ -57,9 +61,9 @@ public class FenetrePrincipale extends JFrame {
 	private void addJPanels(){
 	    
 		// Create the panels
-		topLeft = new FenetrePerspective("Perspective 1", (int) (width * 0.7), (int) (height * 0.4), 0,0);
-		bottomLeft = new FenetrePerspective("Perspective 2", (int) (width*0.7),(int) (height*0.4), 0, (int) (height*0.4));
-		topRight = new FenetreVignette("Vignette", (int) (width * 0.3), (int) (height * 0.4), (int) (width * 0.7), 0);
+		topLeft = new FenetrePerspective("Perspective 1", (int) (width * 0.7), (int) (height * 0.4), 0, 0, new Perspective());
+		bottomLeft = new FenetrePerspective("Perspective 2", (int) (width*0.7),(int) (height*0.4), 0, (int) (height*0.4), new Perspective());
+		topRight = new FenetreVignette("Vignette", (int) (width * 0.3), (int) (height * 0.4), (int) (width * 0.7), 0, new Vignette());
 
 		// Ajout des InternalFrames
         desktopPane.add(topLeft);		// Add Perspective1

--- a/src/vue/FenetreVignette.java
+++ b/src/vue/FenetreVignette.java
@@ -3,24 +3,30 @@ package vue;
 import javax.swing.JInternalFrame;
 import javax.swing.JPanel;
 import model.Observateur;
+import model.Vignette;
 
+@SuppressWarnings("serial")
 public class FenetreVignette extends JInternalFrame implements Observateur {
 	
 	// Attributs
 	JPanel vignette;
+	Vignette vignetteM; //le modèle de cette vue
 	
-	public FenetreVignette(String label, int width, int height, int locationX, int locationY){
+	public FenetreVignette(String label, int width, int height, int locationX, int locationY, Vignette vignetteM){
 		super(label, true, true, true, true);
 		
-		// Specifications de la perspective
+		// Specifications de la vignette
 		vignette = new JPanel();
-
+				
 		// Ajout
 		setContentPane(vignette);
 		setClosable(false);
 	    setSize(width, height);
 	    setLocation(locationX, locationY);
 	   	setVisible(true);
+	   		   	
+	   	this.vignetteM = vignetteM;
+	   	this.vignetteM.setObservateur(this); //Enregistre cette vue auprès de son modèle en tant qu'observateur
 	}
 
 	@Override


### PR DESCRIPTION
Remplace les constructeurs des modèles par des setObservateur(). Rajoute les attributs modèles dans les classes vues. Rectifie les constructeurs des vues.